### PR TITLE
tests/libzip-examples/zip-cat: init and test automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The following dependencies needs to be setup before building with Meson.
     *   Ninja, Samurai, or other Meson backends
     *   Pkg-Config
 *   Test dependencies
+    *   Bash
+    *   FindUtils (for the `find` command)
     *   ShellCheck
     *   InfoZip Unzip (the `unzip` command)
     *   InfoZip Zip (the `zip` command)

--- a/test/libzip_examples/meson.build
+++ b/test/libzip_examples/meson.build
@@ -11,3 +11,7 @@ test('libzip-example-no-op', exe_libzip_example_no_op)
 exe_libzip_example_stat = executable('zip-stat', [ 'zip_stat.c' ],
   dependencies: deps_libzip_example,
 )
+
+exe_libzip_example_cat = executable('zip-cat', [ 'zip_cat.c' ],
+  dependencies: deps_libzip_example,
+)

--- a/test/libzip_examples/meson.build
+++ b/test/libzip_examples/meson.build
@@ -15,3 +15,20 @@ exe_libzip_example_stat = executable('zip-stat', [ 'zip_stat.c' ],
 exe_libzip_example_cat = executable('zip-cat', [ 'zip_cat.c' ],
   dependencies: deps_libzip_example,
 )
+
+exe_test_zip_cat_hello = find_program('./test-zip-cat-hello')
+
+test('shellcheck-test-zip-cat-hello', exe_shellcheck,
+args: [ '-x', '-P', meson.current_source_dir(), exe_test_zip_cat_hello.full_path() ],
+)
+
+test('libzip-example-cat-hello', exe_test_zip_cat_hello,
+args: [
+  exe_libzip_example_cat.full_path(),
+  sample_hello.full_path(),
+],
+depends: [
+  exe_libzip_example_cat,
+  sample_hello,
+],
+)

--- a/test/libzip_examples/test-zip-cat-hello
+++ b/test/libzip_examples/test-zip-cat-hello
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -x -eu -o pipefail
+
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "$0")/../prepare_workdir.sh"
+
+# Check the number of input arguments
+if (( "$#" < 1 )); then
+	echo "Expect ZIP_CAT_PATH or ZIP_CAT_PATH SAMPLE_PATH" >&1
+	exit 1
+fi
+
+ZIP_CAT_PATH="$1"
+
+if (( "$#" >= 2 )); then
+	SAMPLE="$2"
+else
+	SAMPLE="$(dirname "$0")/../samples/sample_hello.zip"
+fi
+[[ -f "$SAMPLE" ]] || [[ -L "$SAMPLE" ]] # Assert the sample ZIP file exists
+
+SAMPLE="$(realpath "$SAMPLE")"
+[[ -f "$SAMPLE" ]] || [[ -L "$SAMPLE" ]] # Assert the sample ZIP file exists after path resolution
+
+pushd "$WORKDIR"
+unzip "$SAMPLE"
+popd
+
+# Check if the content of all the regular files being `zip-cat`ed
+# is the same as the original ones before archiving.
+while ISF="" read -r -d $'\0' FILE; do
+    # Remove "${WORKDIR}/" prefix from the string "$FILE"
+    # to get the sub-directory of the file inside the archive
+	SUBDIR="${FILE:${#WORKDIR}+1}"
+    # Compare the content read with the source file
+	diff <("$ZIP_CAT_PATH" "$SAMPLE" "$SUBDIR") "$FILE"
+done < <(find "$WORKDIR" -mindepth 1 -type f -print0)

--- a/test/libzip_examples/zip_cat.c
+++ b/test/libzip_examples/zip_cat.c
@@ -1,0 +1,74 @@
+#include <zip.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+// Size of buffer_cat
+#ifndef BUFFER_SIZE_CAT
+#define BUFFER_SIZE_CAT 4096
+#endif /* BUFFER_SIZE_CAT */
+
+int main(int argc, char *argv[])
+{
+	// Integer to store exit status
+	int ret_full = EXIT_SUCCESS;
+	// Check the number of input arguments
+	if (argc <= 2) {
+		fprintf(stderr, "zip-cat: Expect arguments ZIPFILE SUBPATH\n");
+		return EXIT_FAILURE;
+	}
+	// Path to the ZIP archive
+	const char *path_zipfile = argv[1];
+	// Sub-path of the file inside the archive
+	const char *subpath = argv[2];
+	// Integer to store the error code from libzip functions
+	int errno_zip = 0;
+	// Pointer to the structure representing the ZIP archive being opened
+	// Open the ZIP archive
+	struct zip *p_zip_in = zip_open(path_zipfile, ZIP_RDONLY, &errno_zip);
+	if (!p_zip_in) {
+		fprintf(stderr, "zip-cat: zip_open: Failed with exit code %d\n",
+			errno_zip);
+		return errno_zip;
+	}
+	// Pointer to the structure representing the file inside the ZIP archive
+	// Open the file inzide the ZIP archive by specifying the subdir
+	struct zip_file *p_file_target = zip_fopen(p_zip_in, subpath, 0);
+	if (!p_file_target) {
+		fprintf(stderr,
+			"zip-cat: zip_fopen: Failed to open subpath %s in ZIP file %s",
+			subpath, path_zipfile);
+		ret_full = EXIT_FAILURE;
+		goto finalize_zip_in;
+	}
+	// Content buffer to cat
+	char *buffer_cat[BUFFER_SIZE_CAT];
+	// Number of bytes actually read
+	zip_int64_t nbytes_read;
+	// Read from the file inside the ZIP archive
+	// Loop until EOL has already reached during the previous iteration
+	while ((nbytes_read = zip_fread(p_file_target, buffer_cat,
+					BUFFER_SIZE_CAT)) > 0) {
+		// Write what is read out to stdin
+		fwrite(buffer_cat, nbytes_read, 1, stdout);
+	}
+	// Negative read-byte means error during zip_fread().
+	if (nbytes_read < 0) {
+		fprintf(stderr, "zip-cat: zip_fead: Failed");
+		ret_full = EXIT_FAILURE;
+		goto finalize_file_target;
+	}
+finalize_file_target:
+	// Close the file inside the ZIP archive
+	// if the pointer is not NULL
+	if (p_file_target) {
+		zip_fclose(p_file_target);
+	}
+finalize_zip_in:
+	// Close the ZIP archive
+	// if the pointer is not NULL
+	if (p_zip_in) {
+		zip_close(p_zip_in);
+	}
+	return ret_full;
+}


### PR DESCRIPTION
This PR adds zip-cat executable and a related test to get an idea about how libzip works.

It depends on #2, which needs to merge first so that subsequent PRs including this one can be merged.