### PR TITLE
Nix packaging: libtree -> libtree-c to avoid naming colflict

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,17 +6,13 @@
 , pkg-config
 , fuse
 , fuse3
-, libtree ? null
+, libtree-c ? callPackage ./libtree-c.nix { }
 , libzip
 , osxfuse
 , shellcheck
-, useMesonBuiltinLibtree ? false
 , self ? callPackage ./. { fuse = if stdenv.hostPlatform.isDarwin then osxfuse else fuse3; }
 }:
 
-let
-  libtreeBulitin = callPackage ./libtree.nix { };
-in
 stdenv.mkDerivation {
   pname = "zipfs-rw";
   version = "0.1.0";
@@ -34,11 +30,11 @@ stdenv.mkDerivation {
           fuse = fuse3;
           self = self.passthru.tests.zipfs-rw-fuse3;
         };
-        zipfs-rw-nix-builtin-libtree = self.override {
-          libtree = null;
+        zipfs-rw-nix-builtin-libtree-c = self.override {
+          libtree-c = callPackage ./libtree-c.nix { };
         };
-        zipfs-rw-meson-builtin-libtree = self.override {
-          useMesonBuiltinLibtree = true;
+        zipfs-rw-meson-builtin-libtree-c = self.override {
+          libtree-c = null;
         };
       }
     // lib.optionalAttrs stdenv.hostPlatform.isDarwin
@@ -58,10 +54,9 @@ stdenv.mkDerivation {
 
   buildInputs = [
     fuse
+    libtree-c
     libzip
   ]
-  ++ lib.optional (!useMesonBuiltinLibtree)
-    (if isNull libtree then libtreeBulitin else libtree)
   ;
 
   doCheck = true;

--- a/flake.lock
+++ b/flake.lock
@@ -15,7 +15,7 @@
         "type": "github"
       }
     },
-    "libtree-source": {
+    "libtree-c-source": {
       "flake": false,
       "locked": {
         "lastModified": 1413485735,
@@ -50,7 +50,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "libtree-source": "libtree-source",
+        "libtree-c-source": "libtree-c-source",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,10 @@
 {
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
-  inputs.libtree-source.url = "github:fbuihuu/libtree";
-  inputs.libtree-source.flake = false;
+  inputs.libtree-c-source.url = "github:fbuihuu/libtree";
+  inputs.libtree-c-source.flake = false;
 
-  outputs = { self, flake-utils, nixpkgs, libtree-source, ... }:
+  outputs = { self, flake-utils, nixpkgs, libtree-c-source, ... }:
     let
       isRelease = false;
     in
@@ -12,13 +12,14 @@
       let
         lib = nixpkgs.lib;
         pkgs = nixpkgs.legacyPackages.${system};
-        libtreeBulitin = pkgs.callPackage ./libtree.nix { };
-        libtree = libtreeBulitin.overrideAttrs (oldAttrs: {
-          version = libtree-source.lastModifiedDate;
-          src = libtree-source;
+        libtree-c-builtin = pkgs.callPackage ./libtree-c.nix { };
+        libtree-c = libtree-c-builtin.overrideAttrs (oldAttrs: {
+          version = libtree-c-source.lastModifiedDate;
+          src = libtree-c-source;
         });
         zipfs-rw = (pkgs.callPackage ./. {
           fuse = if pkgs.stdenv.isDarwin then pkgs.osxfuse else pkgs.fuse3;
+          inherit libtree-c;
           self = zipfs-rw;
         }).overrideAttrs (oldAttrs: lib.optionalAttrs (!isRelease) {
           pname = oldAttrs.pname + "-unstable";
@@ -30,8 +31,8 @@
         packages = {
           default = zipfs-rw;
           inherit
-            libtree
-            libtreeBulitin
+            libtree-c
+            libtree-c-builtin
             zipfs-rw
             ;
         };

--- a/libtree-c.nix
+++ b/libtree-c.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   '';
 
   meta = with lib; {
-    description = "A library which implements a couple of famous binary search trees";
+    description = "A C library implementing famous binary search trees in Linux-kernel style";
     homepage = "https://github.com/fbuihuu/libtree";
     license = licenses.lgpl21Only;
     platforms = platforms.all;

--- a/src/zipfs_rw.h
+++ b/src/zipfs_rw.h
@@ -1,0 +1,15 @@
+#ifndef __ZIPFS_RW_H__
+#define __ZIPFS_RW_H__
+
+#include <libtree.h>
+
+#include <stdbool.h>
+#include <stddef.h>
+
+typedef struct node_de_vd_tree {
+    size_t n_children;
+    struct node_bidi_ndtree *p_parent;
+    struct node_dirtree *p_children;
+};
+
+#endif /* __ZIPFS_RW_H__ */


### PR DESCRIPTION
This PR is to fix the naming collision brought by 1815e0001c66e414389bb8293566ab785533728f in #5.

Please file an issue of leave a comment should things go wrong after merge.